### PR TITLE
Added compile-time checks for AVX2 availability

### DIFF
--- a/always_false.h
+++ b/always_false.h
@@ -1,0 +1,4 @@
+#pragma once
+
+template<typename T> struct always_false { const static bool value = false; };
+template<typename T> inline constexpr bool always_false_v = always_false<T>::value;

--- a/avxMul.h
+++ b/avxMul.h
@@ -2,6 +2,7 @@
 #include "avxSimd.h"
 
 void avxMul2(int* result, const int* a, const int* b, int n, int m, int q) {
+#ifdef AVX2_IS_AVAILABLE
     for (int i = 0; i < n; ++i) {
         int j = 0;
         for (; j <= q - 8; j += 8) {
@@ -21,8 +22,10 @@ void avxMul2(int* result, const int* a, const int* b, int n, int m, int q) {
             result[j + i * q] = sum;
         }
     }
+#endif
 }
 void avxMul3(int* result, const int* a, const int* b, int n, int m, int q) {
+#ifdef AVX2_IS_AVAILABLE
     for (int i = 0; i < n; ++i) {
         int j = 0;
         for (; j <= q - 16; j += 16) {
@@ -46,8 +49,10 @@ void avxMul3(int* result, const int* a, const int* b, int n, int m, int q) {
             result[j + i * q] = sum;
         }
     }
+#endif
 }
 void avxMul4(int* result, const int* a, const int* b, int n, int m, int q) {
+#ifdef AVX2_IS_AVAILABLE
     for (int i = 0; i < n; ++i) {
         int j = 0;
         for (; j <= q - 32; j += 32) {
@@ -79,8 +84,10 @@ void avxMul4(int* result, const int* a, const int* b, int n, int m, int q) {
             result[j + i * q] = sum;
         }
     }
+#endif
 }
 void avxMul5(int* result, const int* a, const int* b, int n, int m, int q) {
+#ifdef AVX2_IS_AVAILABLE
     for (int i = 0; i < n*q; ++i) {
         result[i] = 0;
     }
@@ -118,9 +125,11 @@ void avxMul5(int* result, const int* a, const int* b, int n, int m, int q) {
             }
         }
     }
+#endif
 }
 
 void avxMul6(int* result, const int* a, const int* b, int n, int m, int q) {
+#ifdef AVX2_IS_AVAILABLE
     for (int i = 0; i < n*q; ++i) {
         result[i] = 0;
     }
@@ -190,8 +199,10 @@ void avxMul6(int* result, const int* a, const int* b, int n, int m, int q) {
             }
         }
     }
+#endif
 }
 template<typename T> void avxMul7(T* result, const T* a, const T* b, int n, int m, int q) {
+#ifdef AVX2_IS_AVAILABLE
     for (int i = 0; i < n*q; ++i) {
         result[i] = T{};
     }
@@ -265,8 +276,10 @@ template<typename T> void avxMul7(T* result, const T* a, const T* b, int n, int 
             }
         }
     }
+#endif
 }
 template<typename T> void avxMul8(T* result, const T* a, const T* b, int n) {
+#ifdef AVX2_IS_AVAILABLE
     for (int i = 0; i < n*n; ++i) {
         result[i] = T{};
     }
@@ -322,8 +335,10 @@ template<typename T> void avxMul8(T* result, const T* a, const T* b, int n) {
         }
     }
     AVX256::alignedArrayDealloc(mat2);
+#endif
 }
 template<int n, int m, int q, typename T> void avxMul7(T* result, const T* a, const T* b) {
+#ifdef AVX2_IS_AVAILABLE
     for (int i = 0; i < n*q; ++i) {
         result[i] = T{};
     }
@@ -397,4 +412,5 @@ template<int n, int m, int q, typename T> void avxMul7(T* result, const T* a, co
             }
         }
     }
+#endif
 }

--- a/strassen.h
+++ b/strassen.h
@@ -115,7 +115,8 @@ auto strassen(const MatrixInterface<M1>& a, const MatrixInterface<M2>& b, int st
 }
 template<typename M1, typename M2>
 auto strassenAvx(const MatrixInterface<M1>& a, const MatrixInterface<M2>& b, int steps) {
-    return strassenWithStaticPadding<BaseOperationType::Avx>(a, b, steps);
+    if constexpr (AVX256::IsAvailable) return strassenWithStaticPadding<BaseOperationType::Avx>(a, b, steps);
+    else static_assert(AVX256::IsAvailable && always_false_v<M1>, AVX256_StaticAssertMessage);
 }
 
 template<BaseOperationType opType, int Steps, typename M1, typename M2> auto strassenImpl(const MatrixInterface<M1>& a, const MatrixInterface<M2>& b, std::false_type) {
@@ -156,7 +157,8 @@ template<int Steps, typename M1, typename M2> auto strassen(const MatrixInterfac
     return strassenImpl<BaseOperationType::Naive, Steps>(a, b);
 }
 template<int Steps, typename M1, typename M2> auto strassenAvx(const MatrixInterface<M1>& a, const MatrixInterface<M2>& b) {
-    return strassenImpl<BaseOperationType::Avx, Steps>(a, b);
+    if constexpr (AVX256::IsAvailable) return strassenImpl<BaseOperationType::Avx, Steps>(a, b);
+    else static_assert(AVX256::IsAvailable && always_false_v<M1>, AVX256_StaticAssertMessage);
 }
 
 template<typename T> void copy(T* dst, T* src, int n, int m, int effDst, int effSrc) {
@@ -682,7 +684,8 @@ auto lowLevelStrassen(const MatrixInterface<M1>& a, const MatrixInterface<M2>& b
 }
 template<typename M1, typename M2>
 auto lowLevelAvxStrassen(const MatrixInterface<M1>& a, const MatrixInterface<M2>& b, int steps) {
-    return lowLevelStrassen<BaseOperationType::Avx>(a, b, steps);
+    if constexpr (AVX256::IsAvailable) return lowLevelStrassen<BaseOperationType::Avx>(a, b, steps);
+    else static_assert(AVX256::IsAvailable && always_false_v<M1>, AVX256_StaticAssertMessage);
 }
 
 
@@ -953,7 +956,8 @@ auto minSpaceStrassen(const MatrixInterface<M1>& a, const MatrixInterface<M2>& b
 }
 template<typename M1, typename M2>
 auto minSpaceAvxStrassen(const MatrixInterface<M1>& a, const MatrixInterface<M2>& b, int steps) {
-    return minSpaceStrassen<BaseOperationType::Avx>(a, b, steps);
+    if constexpr (AVX256::IsAvailable) return minSpaceStrassen<BaseOperationType::Avx>(a, b, steps);
+    else static_assert(AVX256::IsAvailable && always_false_v<M1>, AVX256_StaticAssertMessage);
 }
 template<int Steps, typename M1, typename M2>
 auto minSpaceStrassen(const MatrixInterface<M1>& a, const MatrixInterface<M2>& b) {
@@ -961,5 +965,6 @@ auto minSpaceStrassen(const MatrixInterface<M1>& a, const MatrixInterface<M2>& b
 }
 template<int Steps, typename M1, typename M2>
 auto minSpaceAvxStrassen(const MatrixInterface<M1>& a, const MatrixInterface<M2>& b) {
-    return minSpaceStrassen<Steps, BaseOperationType::Avx>(a, b);
+    if constexpr (AVX256::IsAvailable) return minSpaceStrassen<Steps, BaseOperationType::Avx>(a, b);
+    else static_assert(AVX256::IsAvailable && always_false_v<M1>, AVX256_StaticAssertMessage);
 }


### PR DESCRIPTION
This makes it so if you don't use AVX2 specific functions then you can compile your code without the need for AVX2 support